### PR TITLE
[sensorfw] Use setDataRate() for settings data rates. Fixes JB#60417

### DIFF
--- a/rpm/qtsensors.spec
+++ b/rpm/qtsensors.spec
@@ -12,7 +12,7 @@ BuildRequires:  qt5-qtnetwork-devel
 BuildRequires:  qt5-qtdeclarative-qtquick-devel
 BuildRequires:  qt5-qmake
 BuildRequires:  fdupes
-BuildRequires:  pkgconfig(sensord-qt5)
+BuildRequires:  pkgconfig(sensord-qt5) >= 0.13.0
 
 %description
 Qt is a cross-platform application and UI framework. Using Qt, you can
@@ -43,6 +43,7 @@ This package contains the Sensors import for Qtml
 %package plugin-sensorfw
 Summary:    sensorfw sensors plugin
 Requires:   %{name} = %{version}-%{release}
+Requires:   sensorfw-qt5 >= 0.13.0
 
 %description plugin-sensorfw
 This package contains the sensorfw plugin for sensors

--- a/src/plugins/sensors/sensorfw/sensorfwsensorbase.cpp
+++ b/src/plugins/sensors/sensorfw/sensorfwsensorbase.cpp
@@ -87,12 +87,7 @@ void SensorfwSensorBase::start()
         // dataRate
         QByteArray type = sensor()->type();
         if (type != QTapSensor::type && type != QProximitySensor::type) {
-            int dataRate = sensor()->dataRate();
-            int interval = dataRate > 0 ? 1000 / dataRate : 0;
-            // for testing maximum speed
-            //interval = 1;
-            //dataRate = 1000;
-            m_sensorInterface->setInterval(interval);
+            m_sensorInterface->setDataRate(sensor()->dataRate());
         }
 
         // outputRange


### PR DESCRIPTION
Sensorfwd setInterval() method takes time in milliseconds -parameter which is reciprocal of requested data rate in Hertz. As the time value is an integer, this severely limits the available data rates especially in the high end to: 1000, 500, 333, 250, 200, ... Hz

Switch to using setDataRate() which is available in sensorfwd >= 0.13.0. It is both conceptually better match with qt side sensor interfaces and more future proof as data rate is transferred over D-Bus as floating point value.