### PR TITLE
[sensorfw] Activate sensors on sensorfwd restart. Fixes JB#41999

### DIFF
--- a/src/plugins/sensors/sensorfw/sensorfwsensorbase.cpp
+++ b/src/plugins/sensors/sensorfw/sensorfwsensorbase.cpp
@@ -53,8 +53,7 @@ SensorfwSensorBase::SensorfwSensorBase(QSensor *sensor)
       m_efficientBufferSize(1),
       m_maxBufferSize(1),
       m_available(false),
-      running(false),
-      m_attemptRestart(false)
+      m_startRequested(false)
 
 {
     watcher = new QDBusServiceWatcher("com.nokia.SensorService",QDBusConnection::systemBus(),
@@ -83,6 +82,10 @@ SensorfwSensorBase::~SensorfwSensorBase()
 
 void SensorfwSensorBase::start()
 {
+    // Application has requested that sensor should be started.
+    // Do it now or/and whenever a sensorfwd start/restart happens.
+    m_startRequested = true;
+
     if (m_sensorInterface) {
         // dataRate
         QByteArray type = sensor()->type();
@@ -119,10 +122,10 @@ void SensorfwSensorBase::start()
 
         int returnCode = m_sensorInterface->start().error().type();
         if (returnCode == 0) {
-            running = true;
             return;
-        } else if (returnCode == QDBusError::ServiceUnknown) {
-            m_attemptRestart = true;
+        }
+
+        if (returnCode == QDBusError::ServiceUnknown) {
             qWarning() << "m_sensorInterface did not start, DBus service unknown. Waiting for service registration and retrying.";
         } else {
             qWarning() << "m_sensorInterface did not start, error code:" << returnCode;
@@ -135,8 +138,7 @@ void SensorfwSensorBase::stop()
 {
     if (m_sensorInterface)
         m_sensorInterface->stop();
-    running = false;
-    m_attemptRestart = false;
+    m_startRequested = false;
 }
 
 void SensorfwSensorBase::setRanges(qreal correctionFactor)
@@ -214,7 +216,7 @@ void SensorfwSensorBase::connectToSensord()
         m_remoteSensorManager = 0;
         return;
     }
-    if (running || m_attemptRestart) {
+    if (m_startRequested) {
         stop();
         reinitIsNeeded = true;
         start();

--- a/src/plugins/sensors/sensorfw/sensorfwsensorbase.h
+++ b/src/plugins/sensors/sensorfw/sensorfwsensorbase.h
@@ -106,8 +106,7 @@ private:
 
     QDBusServiceWatcher *watcher;
     bool m_available;
-    bool running;
-    bool m_attemptRestart;
+    bool m_startRequested;
 private slots:
     void connectToSensord();
     void sensordUnregistered();


### PR DESCRIPTION
Sometimes lipstick does not react to orientation changes and sensorfwd restarts do not help. Looks the fault is triggered when sensorfwd is not running or orientation sensor is not available during lipstick startup. The reason is that m_attemptRestart flag is set only when a start attempt fails due to sensorfwd not being present - within a conditional block that is not entered until sensorfwd has been seen to be available. Which then means that any initial start failure can get locked in, and no retries are made by qtsensors code within the application's life time.

When application calls sensor start, always set m_attemptRestart. So that an attempt is made to start the sensor whenever sensorfwd startup is detected, regardless of whether it succeeded earlier or not.